### PR TITLE
ci: upload zipped repository files to S3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,11 @@
 name: Go Test
 
+## TODO: mainだけにする
 on: [push]
+
+env:
+  AWS_REGION: ap-northeast-1
+  ZIP_FILE_NAME: wsperf-application.zip
 
 jobs:
   build:
@@ -15,3 +20,23 @@ jobs:
 
       - name: Test
         run: make test
+
+  deploy:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/actions-application
+
+      - name: Zip repository and upload to S3
+        run: |
+          make zip ZIP_FILE_NAME=${{ env.ZIP_FILE_NAME }}
+          aws s3 cp ${{ env.ZIP_FILE_NAME }} s3://${{ secrets.S3_BUCKET_NAME }}/${{ env.ZIP_FILE_NAME }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,5 +38,5 @@ jobs:
 
       - name: Zip repository and upload to S3
         run: |
-          make zip ZIP_FILE_NAME=${{ env.ZIP_FILE_NAME }}
+          zip -r ${{ env.ZIP_FILE_NAME }} . -x .git/\*
           aws s3 cp ${{ env.ZIP_FILE_NAME }} s3://${{ secrets.S3_BUCKET_NAME }}/${{ env.ZIP_FILE_NAME }}

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,10 @@ generate:
 .PHONY: setup
 setup:
 	sh scripts/setup.sh
+
+## CICD用
+ZIP_FILE_NAME=wsperf-application.zip
+
+.PHONY: zip
+zip:
+	zip -r $(ZIP_FILE_NAME) . -x .git/\*

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,3 @@ generate:
 .PHONY: setup
 setup:
 	sh scripts/setup.sh
-
-## CICD用
-ZIP_FILE_NAME=wsperf-application.zip
-
-.PHONY: zip
-zip:
-	zip -r $(ZIP_FILE_NAME) . -x .git/\*


### PR DESCRIPTION
- このリポジトリのソースコードをZIP化してS3にプッシュします。(.gitディレクトリ以外)
- CodeCommitでは、リポジトリ作成時にS3に置いてあるZIPファイルを展開してソース管理に追加してくれる機能があるので、それに使う予定です。

関連: https://github.com/CyberAgentHack/server-performance-tuning-2023-admin/pull/64