### PR TITLE
ci: build and push image to ECR repository

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,8 @@ on: [push]
 env:
   AWS_REGION: ap-northeast-1
   ZIP_FILE_NAME: wsperf-application.zip
+  ECR_REPOSITORY: caws202305perf
+  IMAGE_TAG: default
 
 jobs:
   build:
@@ -40,3 +42,13 @@ jobs:
         run: |
           zip -r ${{ env.ZIP_FILE_NAME }} . -x .git/\*
           aws s3 cp ${{ env.ZIP_FILE_NAME }} s3://${{ secrets.S3_BUCKET_NAME }}/${{ env.ZIP_FILE_NAME }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+## Build
+FROM golang:1.20-alpine AS build
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY main.go ./
+COPY ./pkg/. ./pkg/
+RUN GOOS=linux GOARCH=amd64 go build -o /wsperf
+
+## Deploy
+FROM gcr.io/distroless/base-debian10
+
+WORKDIR /
+
+COPY --from=build /wsperf /wsperf
+
+EXPOSE 8080
+
+USER nonroot:nonroot
+
+CMD ["/wsperf"]


### PR DESCRIPTION
- アプリケーションをコンテナ化しました
- ↑のイメージをECRのリポジトリにプッシュします(server-performance-tuning-2023の初期状態のDockerイメージを保存しておき、学生用のリソースをデプロイする際は、それをプルして、学生個々人用のリポジトリにpushする感じにしようと思います)