### PR TITLE
ci: add github id to image tag

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,7 @@ phases:
       - echo "Running tests..."
       - go test -v ./...
       - echo "Building Docker image..."
-      - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=$GITHUB_ID-$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - docker build -t $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY:$IMAGE_TAG .
   post_build:
     commands:


### PR DESCRIPTION
- 念の為、学生のgithub idをコンテナイメージのタグにプレフィックスとしてつけておきます。